### PR TITLE
Release v0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this library are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html),
 as well as to [Module version numbering](https://go.dev/doc/modules/version-numbers).
 
 ## [0.0.1](https://github.com/pellared/olog/releases/tag/v0.0.1) - 2025-09-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this library are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+as well as to [Module version numbering](https://go.dev/doc/modules/version-numbers).
+
+## [0.0.1](https://github.com/pellared/olog/releases/tag/v0.0.1) - 2025-09-26
+
+### Added
+
+- `New(options Options) *Logger` that creates a new Logger with the provided options.
+- `Logger` type that provides an ergonomic frontend API for OpenTelemetry structured logging with embedded `log.Logger`.
+- `Options` type that contains configuration options for creating a Logger.
+- `Logger.Trace(ctx context.Context, msg string, args ...any)` that logs a trace message with optional key-value pairs.
+- `Logger.TraceAttr(ctx context.Context, msg string, attrs ...log.KeyValue)` that logs a trace message with the provided attributes.
+- `Logger.TraceEnabled(ctx context.Context) bool` that reports whether the logger emits trace-level log records.
+- `Logger.Debug(ctx context.Context, msg string, args ...any)` that logs a debug message with optional key-value pairs.
+- `Logger.DebugAttr(ctx context.Context, msg string, attrs ...log.KeyValue)` that logs a debug message with the provided attributes.
+- `Logger.DebugEnabled(ctx context.Context) bool` that reports whether the logger emits debug-level log records.
+- `Logger.Info(ctx context.Context, msg string, args ...any)` that logs an info message with optional key-value pairs.
+- `Logger.InfoAttr(ctx context.Context, msg string, attrs ...log.KeyValue)` that logs an info message with the provided attributes.
+- `Logger.InfoEnabled(ctx context.Context) bool` that reports whether the logger emits info-level log records.
+- `Logger.Warn(ctx context.Context, msg string, args ...any)` that logs a warning message with optional key-value pairs.
+- `Logger.WarnAttr(ctx context.Context, msg string, attrs ...log.KeyValue)` that logs a warning message with the provided attributes.
+- `Logger.WarnEnabled(ctx context.Context) bool` that reports whether the logger emits warn-level log records.
+- `Logger.Error(ctx context.Context, msg string, args ...any)` that logs an error message with optional key-value pairs.
+- `Logger.ErrorAttr(ctx context.Context, msg string, attrs ...log.KeyValue)` that logs an error message with the provided attributes.
+- `Logger.ErrorEnabled(ctx context.Context) bool` that reports whether the logger emits error-level log records.
+- `Logger.Log(ctx context.Context, level log.Severity, msg string, args ...any)` that logs a message at the specified level with optional key-value pairs.
+- `Logger.LogAttr(ctx context.Context, level log.Severity, msg string, attrs ...log.KeyValue)` that logs a message at the specified level with the provided attributes.
+- `Logger.Event(ctx context.Context, name string, args ...any)` that logs an event with the specified name and optional key-value pairs.
+- `Logger.EventAttr(ctx context.Context, name string, attrs ...log.KeyValue)` that logs an event with the specified name and the provided attributes.
+- `Logger.With(args ...any) *Logger` that returns a new Logger that includes the given attributes in all log records.
+- `Logger.WithAttr(attrs ...log.KeyValue) *Logger` that returns a new Logger that includes the given attributes in all log records.
+
+<!-- markdownlint-configure-file
+{
+  "MD024": {
+    "siblings_only": true
+  }
+}
+-->

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # olog - OpenTelemetry Logging Facade
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/pellared/olog.svg)](https://pkg.go.dev/github.com/pellared/olog)
+[![Keep a Changelog](https://img.shields.io/badge/changelog-Keep%20a%20Changelog-%23E05735)](CHANGELOG.md)
 [![go.mod](https://img.shields.io/github/go-mod/go-version/pellared/olog)](go.mod)
 [![LICENSE](https://img.shields.io/github/license/pellared/olog)](LICENSE)
 [![Go Report Card](https://goreportcard.com/badge/github.com/pellared/olog)](https://goreportcard.com/report/github.com/pellared/olog)

--- a/README.md
+++ b/README.md
@@ -48,3 +48,7 @@ This module follows several key design principles:
 4. **Compatibility**: Uses OpenTelemetry Logs API as the backend for full compatibility
 5. **Composability**: Supports logger composition through `With()`
 6. **Familiar Patterns**: Similar to `slog` design patterns that Go developers already know
+
+## License
+
+**olog** is licensed under the terms of the [MIT license](LICENSE).


### PR DESCRIPTION
### Added

- `New(options Options) *Logger` that creates a new Logger with the provided options.
- `Logger` type that provides an ergonomic frontend API for OpenTelemetry structured logging with embedded `log.Logger`.
- `Options` type that contains configuration options for creating a Logger.
- `Logger.Trace(ctx context.Context, msg string, args ...any)` that logs a trace message with optional key-value pairs.
- `Logger.TraceAttr(ctx context.Context, msg string, attrs ...log.KeyValue)` that logs a trace message with the provided attributes.
- `Logger.TraceEnabled(ctx context.Context) bool` that reports whether the logger emits trace-level log records.
- `Logger.Debug(ctx context.Context, msg string, args ...any)` that logs a debug message with optional key-value pairs.
- `Logger.DebugAttr(ctx context.Context, msg string, attrs ...log.KeyValue)` that logs a debug message with the provided attributes.
- `Logger.DebugEnabled(ctx context.Context) bool` that reports whether the logger emits debug-level log records.
- `Logger.Info(ctx context.Context, msg string, args ...any)` that logs an info message with optional key-value pairs.
- `Logger.InfoAttr(ctx context.Context, msg string, attrs ...log.KeyValue)` that logs an info message with the provided attributes.
- `Logger.InfoEnabled(ctx context.Context) bool` that reports whether the logger emits info-level log records.
- `Logger.Warn(ctx context.Context, msg string, args ...any)` that logs a warning message with optional key-value pairs.
- `Logger.WarnAttr(ctx context.Context, msg string, attrs ...log.KeyValue)` that logs a warning message with the provided attributes.
- `Logger.WarnEnabled(ctx context.Context) bool` that reports whether the logger emits warn-level log records.
- `Logger.Error(ctx context.Context, msg string, args ...any)` that logs an error message with optional key-value pairs.
- `Logger.ErrorAttr(ctx context.Context, msg string, attrs ...log.KeyValue)` that logs an error message with the provided attributes.
- `Logger.ErrorEnabled(ctx context.Context) bool` that reports whether the logger emits error-level log records.
- `Logger.Log(ctx context.Context, level log.Severity, msg string, args ...any)` that logs a message at the specified level with optional key-value pairs.
- `Logger.LogAttr(ctx context.Context, level log.Severity, msg string, attrs ...log.KeyValue)` that logs a message at the specified level with the provided attributes.
- `Logger.Event(ctx context.Context, name string, args ...any)` that logs an event with the specified name and optional key-value pairs.
- `Logger.EventAttr(ctx context.Context, name string, attrs ...log.KeyValue)` that logs an event with the specified name and the provided attributes.
- `Logger.With(args ...any) *Logger` that returns a new Logger that includes the given attributes in all log records.
- `Logger.WithAttr(attrs ...log.KeyValue) *Logger` that returns a new Logger that includes the given attributes in all log records.