### PR TITLE
Release 0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html),
 as well as to [Module version numbering](https://go.dev/doc/modules/version-numbers).
 
-## [Unreleased](https://github.com/pellared/olog/compare/v0.0.3...HEAD)
+## [Unreleased](https://github.com/pellared/olog/compare/v0.0.4...HEAD)
+
+## [0.0.4](https://github.com/pellared/olog/releases/tag/v0.0.4) - 2025-12-09
 
 ### Changed
 


### PR DESCRIPTION
### Changed

- **BREAKING:** Rename `Logger.TraceEvent(ctx context.Context, name string, args ...any)` to `Logger.Trace(ctx context.Context, eventName string, args ...any)`.
- **BREAKING:** Rename `Logger.DebugEvent(ctx context.Context, name string, args ...any)` to `Logger.Debug(ctx context.Context, eventName string, args ...any)`.
- **BREAKING:** Rename `Logger.InfoEvent(ctx context.Context, name string, args ...any)` to `Logger.Info(ctx context.Context, eventName string, args ...any)`.
- **BREAKING:** Rename `Logger.WarnEvent(ctx context.Context, name string, args ...any)` to `Logger.Warn(ctx context.Context, eventName string, args ...any)`.
- **BREAKING:** Rename `Logger.ErrorEvent(ctx context.Context, name string, args ...any)` to `Logger.Error(ctx context.Context, eventName string, args ...any)`.
- **BREAKING:** Rename `Logger.Event(ctx context.Context, level log.Severity, name string, args ...any)` to `Logger.Log(ctx context.Context, level log.Severity, eventName string, args ...any)`.
- **BREAKING:** Rename `Logger.TraceEventAttr(ctx context.Context, name string, attrs ...log.KeyValue)` to `Logger.TraceAttr(ctx context.Context, eventName string, attrs ...log.KeyValue)`.
- **BREAKING:** Rename `Logger.DebugEventAttr(ctx context.Context, name string, attrs ...log.KeyValue)` to `Logger.DebugAttr(ctx context.Context, eventName string, attrs ...log.KeyValue)`.
- **BREAKING:** Rename `Logger.InfoEventAttr(ctx context.Context, name string, attrs ...log.KeyValue)` to `Logger.InfoAttr(ctx context.Context, eventName string, attrs ...log.KeyValue)`.
- **BREAKING:** Rename `Logger.WarnEventAttr(ctx context.Context, name string, attrs ...log.KeyValue)` to `Logger.WarnAttr(ctx context.Context, eventName string, attrs ...log.KeyValue)`.
- **BREAKING:** Rename `Logger.ErrorEventAttr(ctx context.Context, name string, attrs ...log.KeyValue)` to `Logger.ErrorAttr(ctx context.Context, eventName string, attrs ...log.KeyValue)`.
- **BREAKING:** Rename `Logger.EventAttr(ctx context.Context, level log.Severity, name string, attrs ...log.KeyValue)` to `Logger.LogAttr(ctx context.Context, level log.Severity, eventName string, attrs ...log.KeyValue)`.
- **BREAKING:** Rename `Logger.TraceEventEnabled(ctx context.Context, eventName string) bool` to `Logger.TraceEnabled(ctx context.Context, eventName string) bool`.
- **BREAKING:** Rename `Logger.DebugEventEnabled(ctx context.Context, eventName string) bool` to `Logger.DebugEnabled(ctx context.Context, eventName string) bool`.
- **BREAKING:** Rename `Logger.InfoEventEnabled(ctx context.Context, eventName string) bool` to `Logger.InfoEnabled(ctx context.Context, eventName string) bool`.
- **BREAKING:** Rename `Logger.WarnEventEnabled(ctx context.Context, eventName string) bool` to `Logger.WarnEnabled(ctx context.Context, eventName string) bool`.
- **BREAKING:** Rename `Logger.ErrorEventEnabled(ctx context.Context, eventName string) bool` to `Logger.ErrorEnabled(ctx context.Context, eventName string) bool`.

### Removed

- **BREAKING:** Remove `Logger.Trace(ctx context.Context, msg string, args ...any)`. Use event-based logging with `Logger.Trace(ctx context.Context, eventName string, args ...any)` instead.
- **BREAKING:** Remove `Logger.TraceAttr(ctx context.Context, msg string, attrs ...log.KeyValue)`. Use event-based logging with `Logger.TraceAttr(ctx context.Context, eventName string, attrs ...log.KeyValue)` instead.
- **BREAKING:** Remove `Logger.Debug(ctx context.Context, msg string, args ...any)`. Use event-based logging with `Logger.Debug(ctx context.Context, eventName string, args ...any)` instead.
- **BREAKING:** Remove `Logger.DebugAttr(ctx context.Context, msg string, attrs ...log.KeyValue)`. Use event-based logging with `Logger.DebugAttr(ctx context.Context, eventName string, attrs ...log.KeyValue)` instead.
- **BREAKING:** Remove `Logger.Info(ctx context.Context, msg string, args ...any)`. Use event-based logging with `Logger.Info(ctx context.Context, eventName string, args ...any)` instead.
- **BREAKING:** Remove `Logger.InfoAttr(ctx context.Context, msg string, attrs ...log.KeyValue)`. Use event-based logging with `Logger.InfoAttr(ctx context.Context, eventName string, attrs ...log.KeyValue)` instead.
- **BREAKING:** Remove `Logger.Warn(ctx context.Context, msg string, args ...any)`. Use event-based logging with `Logger.Warn(ctx context.Context, eventName string, args ...any)` instead.
- **BREAKING:** Remove `Logger.WarnAttr(ctx context.Context, msg string, attrs ...log.KeyValue)`. Use event-based logging with `Logger.WarnAttr(ctx context.Context, eventName string, attrs ...log.KeyValue)` instead.
- **BREAKING:** Remove `Logger.Error(ctx context.Context, msg string, args ...any)`. Use event-based logging with `Logger.Error(ctx context.Context, eventName string, args ...any)` instead.
- **BREAKING:** Remove `Logger.ErrorAttr(ctx context.Context, msg string, attrs ...log.KeyValue)`. Use event-based logging with `Logger.ErrorAttr(ctx context.Context, eventName string, attrs ...log.KeyValue)` instead.
- **BREAKING:** Remove `Logger.Log(ctx context.Context, level log.Severity, msg string, args ...any)`. Use event-based logging with `Logger.Log(ctx context.Context, level log.Severity, eventName string, args ...any)` instead.
- **BREAKING:** Remove `Logger.LogAttr(ctx context.Context, level log.Severity, msg string, attrs ...log.KeyValue)`. Use event-based logging with `Logger.LogAttr(ctx context.Context, level log.Severity, eventName string, attrs ...log.KeyValue)` instead.
- **BREAKING:** Remove `Logger.TraceEnabled(ctx context.Context) bool`. Use `Logger.TraceEnabled(ctx context.Context, eventName string) bool` instead.
- **BREAKING:** Remove `Logger.DebugEnabled(ctx context.Context) bool`. Use `Logger.DebugEnabled(ctx context.Context, eventName string) bool` instead.
- **BREAKING:** Remove `Logger.InfoEnabled(ctx context.Context) bool`. Use `Logger.InfoEnabled(ctx context.Context, eventName string) bool` instead.
- **BREAKING:** Remove `Logger.WarnEnabled(ctx context.Context) bool`. Use `Logger.WarnEnabled(ctx context.Context, eventName string) bool` instead.
- **BREAKING:** Remove `Logger.ErrorEnabled(ctx context.Context) bool`. Use `Logger.ErrorEnabled(ctx context.Context, eventName string) bool` instead.